### PR TITLE
Add Orkas to local and edge agents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -234,6 +234,7 @@ graph TD
 - **[Ollama](https://github.com/ollama/ollama)** `🔥 MIT` — The premier local engine for running quantized agent models offline on consumer hardware with zero data leakage.
 - **[Apple CoreML Agent Engine](https://developer.apple.com)** `Proprietary` — On-device framework allowing agents to access local file systems, native apps, and Apple Silicon neural engines securely.
 - **[Jan](https://github.com/janhq/jan)** `AGPL-3.0` — Open-source local desktop AI assistant supporting local tool execution, extension plugins, and offline model runtimes.
+- **[Orkas](https://github.com/Orkas-AI/Orkas)** `MIT` — Open-source desktop workspace that coordinates coding agents in parallel or sequence and supports local OpenAI-compatible model endpoints.
 
 ---
 


### PR DESCRIPTION
## Summary

Add Orkas to Local & Edge as an MIT-licensed desktop workspace for coordinating coding agents. The description is limited to its verified multi-agent workflow and support for local OpenAI-compatible model endpoints.

## Verification

- Confirmed the canonical public repository, license, and current star count.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Orkas to the list of local and edge agents.
  * Included its repository link, license, star count, and parallel-agent workspace description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->