### PR TITLE
Add Agent QA

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -283,6 +283,7 @@ graph TD
 - **[Amazon Q Developer Agent](https://aws.amazon.com/q/developer/)** `🆕 Commercial` — AWS's enterprise engineering agent capable of executing multi-repository feature implementations, dependency upgrades, and cloud security remediations in isolated sandboxes.
 - **[Plandex](https://github.com/plandex-ai/plandex)** `🔥 AGPL-3.0` — Open-source, terminal-native AI coding engine designed for complex, multi-file code tasks with tree-based planning and long-horizon execution.
 - **[AutoCodeRover](https://github.com/nus-apr/auto-code-rover)** `Apache 2.0` — Automated software engineering agent using AST and program structure analysis to navigate codebases and resolve complex GitHub issues.
+- **[Agent QA](https://github.com/vostride/agent-qa)** `Source Available · FSL-1.1-ALv2` — QA agent that authors, executes, and self-repairs natural-language web and mobile regression tests with persistent test memory, a dashboard, CLI, MCP server, and agent skills.
 
 ### ☁️ DevOps, SRE & Cloud Infrastructure
 - **[Kubiya](https://www.kubiya.ai)** `Commercial` — Conversational DevOps and infrastructure automation agent executing operations across Kubernetes, Terraform, and cloud platforms.


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to Engineering & Systems as an application-level QA agent for natural-language web and mobile regression tests.

## NEXUM fit

- **Autonomy:** authors, executes, inspects, and self-repairs multi-step test flows rather than requiring selector-by-selector scripting
- **Modern protocol:** exposes 33 public `agent_qa_*` MCP tools in addition to its CLI, dashboard, and three agent skills
- **Activity and usage:** current public documentation, an npm release updated in June 2026, repository activity in August 2026, and roughly 800 GitHub stars
- **Operational visibility:** run steps, logs, screenshots and other artifacts, failure classification, and a local dashboard

The entry explicitly labels the current FSL-1.1-ALv2 release as source-available rather than open source.

## Validation

- `git diff --check`
- canonical repository link and one scoped entry in the documented format

Disclosure: I am affiliated with Agent QA.
