### PR TITLE
Add YYLO to Engineering & Systems

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -390,6 +390,7 @@ graph TD
 - **[AutoCodeRover](https://github.com/nus-apr/auto-code-rover)** `Apache 2.0` — Automated software engineering agent using AST and program structure analysis to navigate codebases and resolve complex GitHub issues.
 - **[Agent QA](https://github.com/vostride/agent-qa)** `Source Available` — QA agent that authors, executes, and self-repairs natural-language web and mobile regression tests with persistent test memory, a dashboard, CLI, MCP server, and agent skills.
 - **[Qodo (formerly CodiumAI)](https://www.qodo.ai/)** `Commercial` `Agentic Testing` — Agentic code analysis platform offering automated test generation, PR review agents, and context-aware integrity verification.
+- **[YYLO](https://github.com/yylo-dev/yylo)** `MIT` — Open-source command-line orchestrator for coding agents that runs each task in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries, with a risk-based merge queue and receipt-backed repository changes.
 
 ### 6.2. DevOps, SRE & Cloud Infrastructure
 - **[Kubiya](https://www.kubiya.ai)** `Commercial` — Conversational DevOps and infrastructure automation agent executing operations across Kubernetes, Terraform, and cloud platforms.


### PR DESCRIPTION
## Summary

Adds **YYLO** — an open-source, MIT-licensed command-line orchestrator for coding agents — to `### 6.1. Engineering & Systems`, alongside the terminal-native agents it orchestrates (Claude Code, Codex CLI, OpenCode, Aider, SWE-agent, Plandex).

YYLO runs each task in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries; a risk-based merge queue owns review, and every repository change is receipt-backed.

## NEXUM Standard

- **Autonomy Tier** — delegates full task lifecycles (start → implement → validate → merge) to coding-agent subagents without micro-management ✅
- **Community Velocity** — daily pushes since January 2026; installable via npm (`@yylo/cli`, ~560 downloads/month); documented README ✅
- **Operational Safety** — typed validation boundaries, risk-scaled review, and hash-linked receipts/manifests for repository changes ✅
- Protocol note, stated honestly: YYLO's integration surface is coding-agent orchestration (Pi and Codex subagents) rather than MCP/A2A — flagging per the NEXUM Standard rather than overclaiming.

## Changes

- [x] Followed the standardized format: `- **[Name](Link)** `License` — Description`
- [x] Placed in the correct architectural layer (Engineering & Systems)
- [x] Single-line addition, no other changes (+1/−0)

## Disclosure

I'm on the team that builds YYLO. This PR was prepared with an AI coding agent and reviewed by a human; every description phrase is taken verbatim from the [YYLO README](https://github.com/yylo-dev/yylo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added YYLO to the Engineering & Systems directory.
  * Identified YYLO as an MIT-licensed, open-source command-line orchestrator for coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->